### PR TITLE
PR-3782: fix Jenkins slave checksum file issue

### DIFF
--- a/tasks/slave.yml
+++ b/tasks/slave.yml
@@ -22,21 +22,21 @@
   apt: name=daemon state=present
   when: ansible_os_family|lower == 'debian'
 
-- name: Get jenkins slave package checksum file
-  get_url:
-    url:  "{{ jenkins_slave_checksum_file_url }}"
-    dest: "{{ jenkins_slave_home }}"
-
-- name: Get checksum of jenkins slave package
-  shell: >
-      cat {{ jenkins_slave_home }}/{{ jenkins_slave_checksum_file }}
-  register: chksum
+#- name: Get jenkins slave package checksum file
+#  get_url:
+#    url:  "{{ jenkins_slave_checksum_file_url }}"
+#    dest: "{{ jenkins_slave_home }}"
+#
+#- name: Get checksum of jenkins slave package
+#  shell: >
+#      cat {{ jenkins_slave_home }}/{{ jenkins_slave_checksum_file }}
+#  register: chksum
 
 - name: Download jenkins slave package
   get_url:
     url:      "{{ jenkins_slave_jar_url }}"
     dest:     "{{ jenkins_slave_home }}/{{ jenkins_slave_jar }}"
-    checksum: "md5:{{ chksum.stdout }}"
+#    checksum: "md5:{{ chksum.stdout }}"
   notify: Restart jenkins slave
 
 - name: Create jenkins slave startup config file | Debian


### PR DESCRIPTION
commented checksum download and verify for below issue:
```
00:01:27.601  TASK [o2-priority.jenkins : Get jenkins slave package checksum file] ***********
00:01:28.152  fatal: [jenkins-slave0.tools.priority.internal]: FAILED! => {"changed": false, "dest": "//data/jenkins-slave", "gid": 1001, "group": "jenkins-slave", "mode": "0755", "msg": "Request failed", "owner": "jenkins-slave", "response": "HTTP Error 308: Permanent Redirect", "size": 4096, "state": "directory", "status_code": 308, "uid": 1001, "url": "http://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/3.25/swarm-client-3.25.jar.md5"}
00:01:28.152  	to retry, use: --limit @/data/jenkins/workspace/priority-infra-tools-pipeline/infra-priority-tools/ansible/playbooks/jenkins-slave.retry
00:01:28.152  
00:01:28.152  PLAY RECAP *********************************************************************
00:01:28.152  jenkins-slave0.tools.priority.internal : ok=41   changed=6    unreachable=0    failed=1   
00:01:28.152  
```